### PR TITLE
Changed src.transform to src.affine... will have to change it back so…

### DIFF
--- a/mapio/gdal.py
+++ b/mapio/gdal.py
@@ -108,7 +108,7 @@ class GDALGrid(Grid2D):
         geodict = {}
 
         with rasterio.open(filename) as src:
-            aff = src.transform
+            aff = src.affine
             geodict['dx'] = aff.a
             geodict['dy'] = -1*aff.e
             geodict['xmin'] = aff.xoff + geodict['dx']/2.0


### PR DESCRIPTION
…meday because the use of these two attributes is in flux.  At rasterio 1.0a9, src.transform returns an array, and generates a warning.  src.affine returns a deprecated warning, but an affine object.  someday src.transform will return an affine object (what we want), but not in this release.